### PR TITLE
Restrict type of value to be converted (will no longer convert hex va…

### DIFF
--- a/parse_eth.js
+++ b/parse_eth.js
@@ -4,6 +4,8 @@ if (typeof parseEth === 'undefined') {
             const number = window.getSelection().toString();
             const result = parseInt(number) / 10e17
 
+            if (number.startsWith('0x')) return;
+
             if (isNaN(result) || result == 0 || result < 0.009) {
                 return
             }


### PR DESCRIPTION
…lues).

Will no longer allow user to convert hex value (ex. transaction hash : 0x0c094b6758b5f25fae96bb5c84f6e9c355992cfc059c0b3231e4f00f79e2c8ff) into misleading ETH value. 

